### PR TITLE
Directly link to support instead of referring to Quick Links

### DIFF
--- a/assets/js/messages.json
+++ b/assets/js/messages.json
@@ -57,7 +57,7 @@
             "c297": [{
                 "project": "mc",
                 "name": "Duplicate of MC-297",
-                "message": "*Thank you for your report!*\nWe're actually already tracking this issue in *MC-297*, so I've resolved and linked this ticket as a duplicate.\n\nThis is known to be a problem with your computer.\n-- Update your [graphics card drivers|https://help.minecraft.net/hc/en-us/articles/360029643912--Updating-video-card-drivers]. (Do not rely on automatic updates)\n-- If you are using Java arguments to increase the amount of memory, please reduce it to the default 512MB.\n-- If that did not help, please use the *community support* link below.\n\n%quick_links%",
+                "message": "*Thank you for your report!*\nWe're actually already tracking this issue in *MC-297*, so I've resolved and linked this ticket as a duplicate.\n\nThis is known to be a problem with your computer.\n-- Update your [graphics card drivers|https://help.minecraft.net/hc/en-us/articles/360029643912--Updating-video-card-drivers]. (Do not rely on automatic updates)\n-- If you are using Java arguments to increase the amount of memory, please reduce it to the default 512MB.\n-- If that did not help, please contact the *[Community Support|https://minecrafthopper.net/help/technical-support-resources/]*.\n\n%quick_links%",
                 "fillname": []
             }]
         },
@@ -73,7 +73,7 @@
             "cacc": [{
                 "project": "mc",
                 "name": "Account issue",
-                "message": "*Thank you for your report!*\nHowever, this issue is {color:#FF5722}*Invalid*{color}.\n\nThis is an account issue. We do not have the tools to help you on this tracker.\nPlease use the *Customer Support* link below.\n\n%quick_links%",
+                "message": "*Thank you for your report!*\nHowever, this issue is {color:#FF5722}*Invalid*{color}.\n\nThis is an account issue. We do not have the tools to help you on this tracker.\nPlease contact the *[Customer Support|https://help.minecraft.net/hc/en-us/requests/new]*.\n\n%quick_links%",
                 "fillname": []
             }]
         },
@@ -262,7 +262,7 @@
             "ctech": [{
                 "project": ["mc", "mcl", "bds"],
                 "name": "Technical support issue",
-                "message": "*Thank you for your report!*\nHowever, this issue is {color:#FF5722}*Invalid*{color}.\n\nThis is a technical support issue; this site is for bug reports only. We do not have the resources to provide you with technical support.\nPlease contact the *community support*, linked below.\n\n%quick_links%",
+                "message": "*Thank you for your report!*\nHowever, this issue is {color:#FF5722}*Invalid*{color}.\n\nThis is a technical support issue; this site is for bug reports only. We do not have the resources to provide you with technical support.\nPlease contact the *[Community Support|https://minecrafthopper.net/help/technical-support-resources/]*.\n\n%quick_links%",
                 "fillname": []
             }]
         }, {
@@ -330,7 +330,7 @@
             "c128302": [{
                 "project": ["mc", "mcl"],
                 "name": "Duplicate of MC-128302",
-                "message": "*Thank you for your report!*\nWe're actually already tracking this issue in *MC-128302*, so I've resolved and linked this ticket as a duplicate.\n\nThis is known to be a problem with your computer.\n-- Update your [graphics card drivers|https://help.minecraft.net/hc/en-us/articles/360029643912--Updating-video-card-drivers]. (Do not rely on automatic updates)\n-- If you are using Java arguments to increase the amount of memory, please reduce it to the default 512MB.\n-- If that did not help, please use the *community support* link below.\n\n%quick_links%",
+                "message": "*Thank you for your report!*\nWe're actually already tracking this issue in *MC-128302*, so I've resolved and linked this ticket as a duplicate.\n\nThis is known to be a problem with your computer.\n-- Update your [graphics card drivers|https://help.minecraft.net/hc/en-us/articles/360029643912--Updating-video-card-drivers]. (Do not rely on automatic updates)\n-- If you are using Java arguments to increase the amount of memory, please reduce it to the default 512MB.\n-- If that did not help, please contact the *[Community Support|https://minecrafthopper.net/help/technical-support-resources/]*.\n\n%quick_links%",
                 "fillname": []
             }]
         }, {


### PR DESCRIPTION
In my opinion, it is better to directly link to the support instead of saying to click the link below.
This is more convenient as you don't have to look for the link further down.

Besides that, it is also easy for unexperienced users to click the "Customer Support" link instead of the "Community Support" or vice versa. Directly linking to the correct support mitigates that.