### PR TITLE
Change the Community Support of MCD to Discord Server

### DIFF
--- a/assets/js/messages.json
+++ b/assets/js/messages.json
@@ -23,7 +23,7 @@
             },
             {
                 "project": "mce",
-                "value": "*Quick Links*:\n📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCE/summary] -- 💬 [Community Support|https://minecrafthopper.net/help/technical-support-resources/] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360033744412-Minecraft-Earth-FAQs]"
+                "value": "*Quick Links*:\n📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCE/summary] -- 💬 [Discord Server|https://discord.gg/minecraftearth] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360033744412-Minecraft-Earth-FAQs]"
             },
             {
                 "project": "bds",

--- a/assets/js/messages.json
+++ b/assets/js/messages.json
@@ -7,7 +7,7 @@
             },
             {
                 "project": "mcd",
-                "value": "*Quick Links*:\n📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCD/summary] -- 💬 [Community Support|https://minecrafthopper.net/help/technical-support-resources/] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360041345271]"
+                "value": "*Quick Links*:\n📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCD/summary] -- 💬 [Discord Server|https://discord.gg/minecraftdungeons] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360041345271]"
             },
             {
                 "project": "mcpe",


### PR DESCRIPTION
The content of the [Community Support](https://minecrafthopper.net/help/technical-support-resources) is mostly about Minecraft and Minecraft: Java Edition. It might be good to change it to the [Discord Server](https://discord.gg/minecraftdungeons) for the MCD project, since there is also a `#community-support` channel in that server.