### PR TITLE
Use GITHUB_TOKEN for auto deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: dist
           GIT_CONFIG_NAME: GitHub Actions


### PR DESCRIPTION
It appears the bug which prevented GITHUB_TOKEN from not causing GitHub pages to be built has been fixed. Therefore GITHUB_TOKEN should be preferred over an access token which one of the members has to create. See also ["Authenticating with the GITHUB_TOKEN"](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) GitHub help article.

See
- https://github.com/JamesIves/github-pages-deploy-action/issues/5
- https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/31266/highlight/true#M743

After merging this pull request, the secret can be removed from this repository and whoever created the access token can revoke it.