### PR TITLE
Add partial translations for quick links

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -4,38 +4,104 @@ variables:
       value: |-
           *Quick Links*:
           📓 [Issue Guidelines|https://bugs.mojang.com/projects/BDS/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [BDS Wiki|https://minecraft.gamepedia.com/Bedrock_Dedicated_Server] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360035131651-Dedicated-Servers-for-Minecraft-on-Bedrock-]
+      localizedValues:
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/BDS/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [BDS 维基|https://minecraft-zh.gamepedia.com/%E5%9F%BA%E5%B2%A9%E7%89%88%E4%B8%93%E7%94%A8%E6%9C%8D%E5%8A%A1%E5%99%A8] -- 📖 [常见问题（英文）|https://help.minecraft.net/hc/en-us/articles/360035131651-Dedicated-Servers-for-Minecraft-on-Bedrock-]
     - project: mc
       value: |-
           *Quick Links*:
-          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MC/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki]
+          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MC/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com]
+      localizedValues:
+        de: |-
+          *Nützliche Links*:
+          📓 [Anleitung zum Melden von Fehlern|https://bugs.mojang.com/projects/MC/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Kundensupport|https://help.minecraft.net/hc/de/requests/new] -- ✍️ [Feedback und Vorschläge|https://feedback.minecraft.net/] -- 📖 [Minecraft Wiki|https://minecraft-de.gamepedia.com]
+        es: |-
+          *Links rapidos*:
+          📓 [Como reportar problemas|https://bugs.mojang.com/projects/MC/summary] -- 💬 [Soporte de la comunidad|https://discord.gg/58Sxm23] -- 📧 [Soporte oficial|https://help.minecraft.net/hc/es/requests/new] -- ✍️ [Sugerencias y opiniones|https://feedback.minecraft.net/] -- 📖 [Wiki|https://minecraft-es.gamepedia.com]
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/MC/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [游戏维基|https://minecraft-zh.gamepedia.com]
     - project: mcapi
       value: |-
           *Quick Links*:
-          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCAPI/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki]
+          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCAPI/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com]
+      localizedValues:
+        de: |-
+          *Nützliche Links*:
+          📓 [Anleitung zum Melden von Fehlern|https://bugs.mojang.com/projects/MCAPI/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Kundensupport|https://help.minecraft.net/hc/de/requests/new] -- ✍️ [Feedback und Vorschläge|https://feedback.minecraft.net/] -- 📖 [Minecraft Wiki|https://minecraft-de.gamepedia.com]
+        es: |-
+          *Links rapidos*:
+          📓 [Como reportar problemas|https://bugs.mojang.com/projects/MCAPI/summary] -- 💬 [Soporte de la comunidad|https://discord.gg/58Sxm23] -- 📧 [Soporte oficial|https://help.minecraft.net/hc/es/requests/new] -- ✍️ [Sugerencias y opiniones|https://feedback.minecraft.net/] -- 📖 [Wiki|https://minecraft-es.gamepedia.com]
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/MCAPI/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [游戏维基|https://minecraft-zh.gamepedia.com]
     - project: mcd
       value: |-
           *Quick Links*:
-          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCD/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360041345271]
+          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCD/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360041345271]
+      localizedValues:
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/MCD/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [游戏维基|https://minecraft-zh.gamepedia.com] -- 📖 [常见问题（英文）|https://help.minecraft.net/hc/en-us/articles/360041345271]
     - project: mce
       value: |-
           *Quick Links*:
-          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCE/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360033744412-Minecraft-Earth-FAQs]
+          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCE/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/articles/360033744412-Minecraft-Earth-FAQs]
+      localizedValues:
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/MCE/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [游戏维基|https://minecraft-zh.gamepedia.com] -- 📖 [常见问题（英文）|https://help.minecraft.net/hc/en-us/articles/360033744412-Minecraft-Earth-FAQs]
     - project: mcl
       value: |-
           *Quick Links*:
-          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCL/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki]
+          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCL/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com]
+      localizedValues:
+        de: |-
+          *Nützliche Links*:
+          📓 [Anleitung zum Melden von Fehlern|https://bugs.mojang.com/projects/MCL/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Kundensupport|https://help.minecraft.net/hc/de/requests/new] -- ✍️ [Feedback und Vorschläge|https://feedback.minecraft.net/] -- 📖 [Minecraft Wiki|https://minecraft-de.gamepedia.com]
+        es: |-
+          *Links rapidos*:
+          📓 [Como reportar problemas|https://bugs.mojang.com/projects/MCL/summary] -- 💬 [Soporte de la comunidad|https://discord.gg/58Sxm23] -- 📧 [Soporte oficial|https://help.minecraft.net/hc/es/requests/new] -- ✍️ [Sugerencias y opiniones|https://feedback.minecraft.net/] -- 📖 [Wiki|https://minecraft-es.gamepedia.com]
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/MCL/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [游戏维基|https://minecraft-zh.gamepedia.com]
     - project: mcpe
       value: |-
           *Quick Links*:
-          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCPE/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com/Minecraft_Wiki]
+          📓 [Issue Guidelines|https://bugs.mojang.com/projects/MCPE/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com]
+      localizedValues:
+        de: |-
+          *Nützliche Links*:
+          📓 [Anleitung zum Melden von Fehlern|https://bugs.mojang.com/projects/MCPE/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Kundensupport|https://help.minecraft.net/hc/de/requests/new] -- ✍️ [Feedback und Vorschläge|https://feedback.minecraft.net/] -- 📖 [Minecraft Wiki|https://minecraft-de.gamepedia.com]
+        es: |-
+          *Links rapidos*:
+          📓 [Como reportar problemas|https://bugs.mojang.com/projects/MCPE/summary] -- 💬 [Soporte de la comunidad|https://discord.gg/58Sxm23] -- 📧 [Soporte oficial|https://help.minecraft.net/hc/es/requests/new] -- ✍️ [Sugerencias y opiniones|https://feedback.minecraft.net/] -- 📖 [Wiki|https://minecraft-es.gamepedia.com]
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/MCPE/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [游戏维基|https://minecraft-zh.gamepedia.com]
     - project: realms
       value: |-
           *Quick Links*:
           📓 [Issue Guidelines|https://bugs.mojang.com/projects/REALMS/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com] -- 📖 [FAQs|https://help.minecraft.net/hc/en-us/sections/360004954931-Minecraft-Realms]
+      localizedValues:
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/REALMS/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [游戏维基|https://minecraft-zh.gamepedia.com] -- 📖 [常见问题（英文）|https://help.minecraft.net/hc/en-us/sections/360004954931-Minecraft-Realms]
     - project: web
       value: |-
           *Quick Links*:
           📓 [Issue Guidelines|https://bugs.mojang.com/projects/WEB/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Customer Support|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [Feedback and Suggestions|https://feedback.minecraft.net/] -- 📖 [Game Wiki|https://minecraft.gamepedia.com]
+      localizedValues:
+        de: |-
+          *Nützliche Links*:
+          📓 [Anleitung zum Melden von Fehlern|https://bugs.mojang.com/projects/WEB/summary] -- 💬 [Community Support|https://discord.gg/58Sxm23] -- 📧 [Kundensupport|https://help.minecraft.net/hc/de/requests/new] -- ✍️ [Feedback und Vorschläge|https://feedback.minecraft.net/] -- 📖 [Minecraft Wiki|https://minecraft-de.gamepedia.com]
+        es: |-
+          *Links rapidos*:
+          📓 [Como reportar problemas|https://bugs.mojang.com/projects/WEB/summary] -- 💬 [Soporte de la comunidad|https://discord.gg/58Sxm23] -- 📧 [Soporte oficial|https://help.minecraft.net/hc/es/requests/new] -- ✍️ [Sugerencias y opiniones|https://feedback.minecraft.net/] -- 📖 [Wiki|https://minecraft-es.gamepedia.com]
+        zh: |-
+          *快捷链接*：
+          📓 [漏洞报告指南（英文）|https://bugs.mojang.com/projects/WEB/summary] -- 💬 [社区支持（英文）|https://discord.gg/58Sxm23] -- 📧 [客户服务（英文）|https://help.minecraft.net/hc/en-us/requests/new] -- ✍️ [反馈与建议（英文）|https://feedback.minecraft.net/] -- 📖 [游戏维基|https://minecraft-zh.gamepedia.com]
   project_id:
     - project: mc
       value: MC


### PR DESCRIPTION
See also #168

# Future Plans
(Copied from #168)
- [ ] Decide if we want to translate these messages in the first place.
- [ ] Polish the English version of `report-not-in-english` if needed. The current message is https://github.com/mojira/helper-messages/blob/5d749f35da78eb6fbd2d08dbbd0effb6087709c7/assets/messages.yml#L817-L827
- [ ] Polish the English version of `i-am-a-bot` if needed. The current message is https://github.com/mojira/helper-messages/blob/5d749f35da78eb6fbd2d08dbbd0effb6087709c7/assets/messages.yml#L446-L448
- [ ] Localize the `quick_links` variable, the `report-not-in-english` message, and the `i-am-a-bot` message.

If we decide to translate these messages, the final comment made by Arisa will include both versions (a localized one and the English one) of the message, formatted as `"$localized\n----\n$english"`.