### PR TITLE
Add shortcuts to messages

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -189,7 +189,7 @@ messages:
       fillname: []
     - project: mce
       name: Crash logged automatically
-      shortcu: autocrash
+      shortcut: autocrash
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -298,7 +298,7 @@ messages:
   duplicate-of-mc-297:
     - project: mc
       name: Duplicate of MC-297
-      shortcut: 297
+      shortcut: '297'
       message: |-
         *Thank you for your report!*
         We're actually already tracking this issue in *MC-297*, so I've resolved and linked this ticket as a duplicate.
@@ -467,6 +467,7 @@ messages:
         - realms
         - web
       name: I am a Bot
+      shortcut: bot
       message:
         "~{color:#888}-- I am a bot. This action was performed automagically!
         Please report any issues in [Discord|https://discordapp.com/invite/rpCyfKV]

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -57,6 +57,7 @@ messages:
   account-issue:
     - project: mc
       name: Account issue
+      shortcut: acc
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -71,6 +72,7 @@ messages:
         - mc
         - mcl
       name: Attach crash report
+      shortcut: crash
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -84,6 +86,7 @@ messages:
   attach-debug-profile-and-report:
     - project: mc
       name: Attach debug profile and report
+      shortcut: debug
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -100,6 +103,7 @@ messages:
   attach-device-information:
     - project: mce
       name: Attach device information
+      shortcut: device
       message: |-
         *Thank you for your report!*
         Could you please include information about your device? Without it we may be unable to reproduce the issue.
@@ -108,6 +112,7 @@ messages:
       fillname: []
     - project: bds
       name: Attach server information
+      shortcut: server
       message: |-
         *Thank you for your report!*
         Could you please include information about your server? Without it we may be unable to reproduce the issue.
@@ -119,6 +124,7 @@ messages:
         - mc
         - mcl
       name: Attach world file
+      shortcut: world
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -131,6 +137,7 @@ messages:
   auth-server-down:
     - project: mc
       name: Auth server down
+      shortcut: auth
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -143,6 +150,7 @@ messages:
   combat-test:
     - project: mc
       name: Combat Test
+      shortcut: combat
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -156,6 +164,7 @@ messages:
   contact-support:
     - project: mcpe
       name: Contact Support
+      shortcut: support
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -170,6 +179,7 @@ messages:
         - mcpe
         - realms
       name: Crash logged automatically
+      shortcut: autocrash
       message: |-
         *Thank you for your report!*
 
@@ -179,6 +189,7 @@ messages:
       fillname: []
     - project: mce
       name: Crash logged automatically
+      shortcu: autocrash
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -192,6 +203,7 @@ messages:
   device-not-supported:
     - project: mce
       name: Device not supported
+      shortcut: devsup
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -215,6 +227,7 @@ messages:
         - realms
         - web
       name: Duplicate
+      shortcut: dup
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -228,6 +241,7 @@ messages:
         - Enter parent issue ID
     - project: bds
       name: Duplicate
+      shortcut: dup
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -252,6 +266,7 @@ messages:
         - realms
         - web
       name: Duplicate (fixed)
+      shortcut: fdup
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -268,6 +283,7 @@ messages:
         - mc
         - mcl
       name: Duplicate of MC-128302
+      shortcut: ogl
       message: |-
         *Thank you for your report!*
         We're actually already tracking this issue in *MC-128302*, so I've resolved and linked this ticket as a duplicate.
@@ -282,6 +298,7 @@ messages:
   duplicate-of-mc-297:
     - project: mc
       name: Duplicate of MC-297
+      shortcut: 297
       message: |-
         *Thank you for your report!*
         We're actually already tracking this issue in *MC-297*, so I've resolved and linked this ticket as a duplicate.
@@ -296,6 +313,7 @@ messages:
   duplicate-of-mcl-5638:
     - project: mcl
       name: Duplicate of MCL-5638
+      shortcut: jre
       message: |-
         *Thank you for your report!*
         We're actually already tracking this issue in *MCL-5638*, so I've resolved and linked this ticket as a duplicate.
@@ -318,6 +336,7 @@ messages:
         - realms
         - web
       name: Duplicate (private)
+      shortcut: pdup
       message: |-
         *Thank you for your report!*
         We're actually already tracking this issue as *%s%* (private), so this ticket is being resolved and linked as a *duplicate*.
@@ -338,6 +357,7 @@ messages:
         - realms
         - web
       name: Duplicate (tech support)
+      shortcut: tdup
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -363,6 +383,7 @@ messages:
         - realms
         - web
       name: Duplicate (wai)
+      shortcut: wdup
       message: |-
         *Thank you for your report!*
         We're tracking this issue as *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -379,6 +400,7 @@ messages:
         - bds
         - mcpe
       name: External server issue
+      shortcut: ext
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -399,6 +421,7 @@ messages:
         - mcpe
         - realms
       name: Feature request
+      shortcut: feat
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -413,6 +436,7 @@ messages:
         - mc
         - mcl
       name: Force debug crash report
+      shortcut: force
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -425,6 +449,7 @@ messages:
   hashtag-issue:
     - project: mcpe
       name: Hashtag issue
+      shortcut: hashtag
       message:
         For any new or ongoing hashtag issues, please create a new ticket for
         any gamertags still affected and use the label {{[chat-filter|https://bugs.mojang.com/issues/?jql=labels+%3D+chat-filter]}}.
@@ -453,6 +478,7 @@ messages:
         - mcl
         - mctest
       name: Incomplete
+      shortcut: inc
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Incomplete*{color}.
@@ -473,6 +499,7 @@ messages:
         - realms
         - web
       name: Incomplete
+      shortcut: inc
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Incomplete*{color}.
@@ -488,6 +515,7 @@ messages:
         - mc
         - mcl
       name: MCL-6550 tech support issue
+      shortcut: resp
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -502,6 +530,7 @@ messages:
         - mc
         - mcl
       name: Minimum requirements not met
+      shortcut: min
       message: |-
         *Thank you for your report!* 
         However, this issue is {color:red}*Invalid*{color}.
@@ -516,6 +545,7 @@ messages:
         - mcl
         - mctest
       name: Modified game
+      shortcut: mod
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -533,6 +563,7 @@ messages:
         - bds
         - mcpe
       name: Modified game
+      shortcut: mod
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -549,6 +580,7 @@ messages:
   modify-entity-during-lifetime:
     - project: mc
       name: Modify entity during lifetime
+      shortcut: nbt
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -568,6 +600,7 @@ messages:
         - mcpe
         - realms
       name: Multiple issues in one report
+      shortcut: mult
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -579,6 +612,7 @@ messages:
   not-available-countries:
     - project: mce
       name: Not available countries/regions
+      shortcut: region
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -593,6 +627,7 @@ messages:
   outdated-client:
     - project: mc
       name: Outdated client
+      shortcut: out
       message: |-
         *Thank you for your report!*
         However, this issue is {color:red}*Invalid*{color}.
@@ -617,6 +652,7 @@ messages:
         - realms
         - web
       name: Panel - Environment Desc.
+      shortcut: env
       message:
         "{panel:borderColor=orange}(!) The environment is supposed to only contain
         PC details.{panel}"
@@ -628,6 +664,7 @@ messages:
         - mcl
         - mcpe
       name: Panel - Future Version
+      shortcut: fut-old
       message:
         "{panel:borderColor=orange}(!) Please do not mark _Unreleased Versions_
         as affected. You don't have access to them yet.{panel}"
@@ -645,6 +682,7 @@ messages:
         - realms
         - web
       name: Panel - Mojang Priority
+      shortcut: prio
       message:
         '{panel:borderColor=orange}(!) Don''t try to change "Mojang Priority".
         It may only be changed by the developers. Consider this a warning.{panel}'
@@ -662,6 +700,7 @@ messages:
         - realms
         - web
       name: Panel - Note
+      shortcut: note
       message: |-
         {panel:title=Note|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}
         %s%
@@ -681,6 +720,7 @@ messages:
         - realms
         - web
       name: Panel - Private issue
+      shortcut: priv
       message:
         "{panel:borderColor=orange}(!) Please do not mark issues as _private_,
         unless your bug report is an exploit or contains information about your username
@@ -699,6 +739,7 @@ messages:
         - realms
         - web
       name: Panel - Unmark private issue
+      shortcut: unpriv
       message:
         "{panel:borderColor=orange}(!) Please do not unmark issues from _private_
         after a moderator had set it that way{panel}"
@@ -716,6 +757,7 @@ messages:
         - realms
         - web
       name: Panel - Workaround
+      shortcut: workaround
       message: |-
         {panel:title=Workaround|borderStyle=dashed|borderColor=#ccc|titleBGColor=#C1F7D6|bgColor=#CEFFFF}
         %s%
@@ -728,6 +770,7 @@ messages:
         - mcpe
         - realms
       name: Parity issue
+      shortcut: parity
       message: |-
         Minecraft has several different editions, and some features vary from edition to edition. Often this happens when one edition evolves faster than another, and tweaks or balances are made that don't propagate immediately to other editions.
         Parity issues are not tracked on the bug tracker but should instead be reported on the [Feedback website|https://feedback.minecraft.net/hc/en-us/community/topics/360001191251-Parity].
@@ -737,6 +780,7 @@ messages:
         - mc
         - mcl
       name: Pirated Minecraft
+      shortcut: pir
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -757,6 +801,7 @@ messages:
         - mctest
         - realms
       name: Provide affected versions
+      shortcut: fut
       message: |-
         {panel:borderColor=orange}(!) Please do not mark _Unreleased Versions_ as affected. You don't have access to them yet.{panel}
         
@@ -776,6 +821,7 @@ messages:
     - project:
         - mc
       name: Provide seed and coordinates
+      shortcut: loc
       message: |-
         _We do not have enough information to reproduce this issue._
 
@@ -803,6 +849,7 @@ messages:
         - mcpe
         - realms
       name: Quick links
+      shortcut: qul
       message: "%quick_links%"
       fillname: []
   report-not-in-english:
@@ -816,6 +863,7 @@ messages:
         - mcpe
         - realms
       name: Report not in English
+      shortcut: lang
       message: |-
         *Thank you for your report!*
         Thank you for taking the time to report a bug. Unfortunately we are only able to accept bug reports in English since it is the common language used on this tracker.
@@ -834,6 +882,7 @@ messages:
         - mc
         - mcl
       name: Technical support issue
+      shortcut: tech
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -846,6 +895,7 @@ messages:
   translation-issue:
     - project: mc
       name: Translation issue
+      shortcut: trans
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -857,6 +907,7 @@ messages:
       fillname: []
     - project: mcl
       name: Translation issue
+      shortcut: trans
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -869,6 +920,7 @@ messages:
   wai:
     - project: mc
       name: Works As Intended
+      shortcut: wai
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Working as Intended*{color}.
@@ -885,6 +937,7 @@ messages:
         - Enter reason/source
     - project: mcpe
       name: Works As Intended
+      shortcut: wai
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Working as Intended*{color}.
@@ -901,6 +954,7 @@ messages:
         - Enter reason/source
     - project: mcl
       name: Works As Intended
+      shortcut: wai
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Working as Intended*{color}.
@@ -926,6 +980,7 @@ messages:
         - mcpe
         - realms
       name: Wrong project
+      shortcut: proj
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.

--- a/messages_schema.json
+++ b/messages_schema.json
@@ -42,6 +42,9 @@
                         "message": {
                             "type": "string"
                         },
+                        "shortcut": {
+                            "type": "string"
+                        },
                         "localizedMessages": {
                             "$ref": "#/definitions/localizedValues"
                         },
@@ -57,6 +60,7 @@
                     "required": [
                         "project",
                         "name",
+                        "shortcut",
                         "message",
                         "fillname"
                     ]


### PR DESCRIPTION
This PR simply adds very short shortcuts to messages (well, all except for the bot message, I didn't see any point in adding it there).

I'm currently transferring over my workflow to use the helper messages repo instead, so I no longer need to maintain a separate copy of the helper messages database.

The reason for adding the shortcuts is to be able to easily input a message into a Mojira text field without the need to visit the external webpage. For instance, when I type "mji-dup", it will expand to the full helper message.

Until now I used a third-party browser extension to do this, however it doesn't work too well and had a few more downsides, so I'm currently in the process of developing a custom browser extension that always stays in sync with the messages from this repo. I'm looking forward to sharing that with you all as well when it's ready.