### PR TITLE
Improve not-reopen-ar message

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -675,7 +675,7 @@ messages:
       name: Not reopen AR ticket
       shortcut: hard-ar
       message: |-
-        This report is currently missing crucial information. Please take a look at other comments to find out what we are looking for.
+        This report is currently missing crucial information. Please take a look at the other comments to find out what we are looking for.
         If you added the required information and a moderator sees your comment, they will reopen and update the report. However, if you think your update to this report has been overlooked or you want to make sure that this report is reopened, you can contact the Mojira staff in [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/].
       fillname: []
   outdated-client:


### PR DESCRIPTION
"Please take a look at other comments" sounds like you should look at any other comments in general, possibly even on other reports (though from the context it might be obvious that this is not the case).
It would therefore be good to write "the other comments" to make it more clear.