### PR TITLE
Added realms project to technical support issue message

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -935,6 +935,7 @@ messages:
         - bds
         - mc
         - mcl
+        - realms
       name: Technical support issue
       shortcut: tech
       message: |-

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -58,6 +58,7 @@ messages:
     - project: 
        - mc
        - web
+       - realms
       name: Account issue
       shortcut: acc
       message: |-

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -55,7 +55,9 @@ variables:
       value: REALMS
 messages:
   account-issue:
-    - project: mc
+    - project: 
+       - mc
+       - web
       name: Account issue
       shortcut: acc
       message: |-
@@ -936,6 +938,7 @@ messages:
         - mc
         - mcl
         - realms
+        - web
       name: Technical support issue
       shortcut: tech
       message: |-


### PR DESCRIPTION
This is due to some realm issues being technical support issues instead. Usually I'd use the MC project one but with the new extension it sorts by project so the message doesn't appear.