### PR TITLE
Improve "Attach new attachment" message

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -487,9 +487,10 @@ messages:
       name: Attach new attachment
       shortcut: attachnew
       message: |-
-        Your report contained an attachment with an invalid extension, so the attachment was removed. 
-        
-        Please remember to only include crashlogs as text files and images as jpg or png instead of using a Word document
+        An attachment with a disallowed file extension has been removed from this ticket.
+
+        Executable files and documents are not allowed as attachments.
+        Please attach crash reports, log files and screenshots as they are instead of pasting them into a document.
       fillname: []
   force-debug-crash-report:
     - project:


### PR DESCRIPTION
Fix #71

Differences to https://github.com/mojira/helper-messages/issues/71#issuecomment-637644770:
- "disallowed" instead of "unallowed" because the latter might be rather uncommon?
- "ticket" instead of "bug report" to be consistent with naming in other messages

"documents" might be too unspecific and could be understood incorrectly, what do you think? Should we add examples ("documents ({{.docx}}, {{.pdf}}, ...") to clarify it?