### PR TITLE
Add message for the Debug Stick being unsupported

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -93,7 +93,7 @@ messages:
   attach-debug-profile-and-report:
     - project: mc
       name: Attach debug profile and report
-      shortcut: stick
+      shortcut: debug
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -247,7 +247,7 @@ messages:
   debug-stick:
     - project: mc
       name: Debug Stick
-      shortcut: debug
+      shortcut: stick
       message: |-
         *Thank you for your report!*
         However, this issue won't be fixed.

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -252,7 +252,7 @@ messages:
         *Thank you for your report!*
         However, this issue won't be fixed.
 
-        Any issues regarding the Debug Stick are not accepted on the bug tracker according to a [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
+        Any issues regarding the Debug Stick are not accepted on the bug tracker according to this [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
 
         %quick_links%
       fillname: []

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -252,7 +252,7 @@ messages:
         *Thank you for your report!*
         However, this issue won't be fixed.
 
-        Any issues regarding the Debug Stick are not accepted on the bug tracker according to this [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
+        Any issues regarding the block states being created or changed using the Debug Stick are not accepted on the bug tracker according to this [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
 
         %quick_links%
       fillname: []

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -244,6 +244,18 @@ messages:
 
         %quick_links%
       fillname: []
+  debug-stick:
+    - project: mc
+      name: Debug Stick
+      shortcut: debug
+      message: |-
+        *Thank you for your report!*
+        However, this issue won't be fixed.
+
+        Any issues regarding the Debug Stick are not accepted on the bug tracker according to a [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
+
+        %quick_links%
+      fillname: []
   device-not-supported:
     - project: mce
       name: Device not supported

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -93,7 +93,7 @@ messages:
   attach-debug-profile-and-report:
     - project: mc
       name: Attach debug profile and report
-      shortcut: debug
+      shortcut: stick
       message: |-
         _We do not have enough information to find the cause of this issue._
 

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -252,7 +252,7 @@ messages:
         *Thank you for your report!*
         However, this issue won't be fixed.
 
-        Any issues regarding the block states being created or changed using the Debug Stick are not accepted on the bug tracker according to this [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
+        Any issues regarding the block states being created or changed by using the Debug Stick are not accepted on the bug tracker according to this [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
 
         %quick_links%
       fillname: []

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -252,7 +252,7 @@ messages:
         *Thank you for your report!*
         However, this issue won't be fixed.
 
-        Any issues regarding the block states being created or changed by using the Debug Stick are not accepted on the bug tracker according to this [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
+        Any issues regarding block states being created or changed by using the Debug Stick are not accepted on the bug tracker according to this [reddit post|https://www.reddit.com/r/Minecraft/comments/7es23r/please_mojang_let_us_keep_the_debug_stick_it_has/dq7fjld/] from Mojang.
 
         %quick_links%
       fillname: []


### PR DESCRIPTION
I think it would be a good idea to have a message explaining how the debug stick is not supported (and includes a link to the reddit post in which it was decided)