### PR TITLE
Clarify that launcher translations for en-us are not tracked on Crowdin

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1117,7 +1117,7 @@ messages:
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
-        Translations are done by the community and take place on the [Crowdin Minecraft Launcher Translation Project|https://crowdin.net/project/minecraft-launcher].
+        Translations for languages other than "English - United States" are done by the community and take place on the [Crowdin Minecraft Launcher Translation Project|https://crowdin.net/project/minecraft-launcher].
         Please use Crowdin for suggesting and adding translations.
 
         %quick_links%


### PR DESCRIPTION
Uses "English - United States" instead of "English (US)" because that is how the launcher calls it in the language selection dropdown.