### PR TITLE
Change default amount of recommended RAM to 2GB instead of 512MB

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -331,7 +331,7 @@ messages:
 
         This is known to be a problem with your computer.
         -- Update your [graphics card drivers|https://help.minecraft.net/hc/en-us/articles/360029643912--Updating-video-card-drivers]. (Do not rely on automatic updates)
-        -- If you are using Java arguments to increase the amount of memory, please reduce it to the default 512MB.
+        -- If you are using Java arguments to increase the amount of memory, please reduce it to the default 2GB.
         -- If that did not help, please contact the *[Community Support|https://discord.gg/58Sxm23]*.
 
         %quick_links%
@@ -346,7 +346,7 @@ messages:
 
         This is known to be a problem with your computer.
         -- Update your [graphics card drivers|https://help.minecraft.net/hc/en-us/articles/360029643912--Updating-video-card-drivers]. (Do not rely on automatic updates)
-        -- If you are using Java arguments to increase the amount of memory, please reduce it to the default 512MB.
+        -- If you are using Java arguments to increase the amount of memory, please reduce it to the default 2GB.
         -- If that did not help, please contact the *[Community Support|https://discord.gg/58Sxm23]*.
 
         %quick_links%


### PR DESCRIPTION
Fixes #109. Previously, these messages said to revert the default amount of RAM to 512MB, but that is no longer the default (now it is 2GB).

This is my first pull request in mojira. I have seen other pull requests have checklists and stuff like that but I don't know what those are used for (or how to make them) so if it needs one of those then you can add it if you'd like.

I think this is the correct file to change :)