### PR TITLE
Add a message for reports duplicating MCL-14369

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -360,7 +360,7 @@ messages:
         We're actually already tracking this issue in *MCL-5638*, so this ticket is being resolved and linked as a *duplicate*.
 
         This is known to be an issue involving detection of the Java runtime.
-        Please take a look at the Moderator’s Note on that ticket to see solutions to your issue.
+        Please take a look at the Moderator Note on that ticket to see solutions to your issue.
 
         %quick_links%
       fillname: []

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -366,7 +366,7 @@ messages:
       fillname: []
   duplicate-of-mcl-14369:
     - project: mcl
-      name: Duplicate of MCL-5638
+      name: Duplicate of MCL-14369
       shortcut: '14369'
       message: |-
         *Thank you for your report!*

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -364,6 +364,19 @@ messages:
 
         %quick_links%
       fillname: []
+  duplicate-of-mcl-14369:
+    - project: mcl
+      name: Duplicate of MCL-5638
+      shortcut: '14369'
+      message: |-
+        *Thank you for your report!*
+        We're actually already tracking this issue in *MCL-14369*, so this ticket is being resolved and linked as a *duplicate*.
+
+        Please take a look at the Moderator Note on that ticket to see a possible solution to your issue.
+        If that did not help, please join the *[Community Support Discord|https://discord.gg/58Sxm23]* for help.
+
+        %quick_links%
+      fillname: []
   duplicate-of-mc-108:
     - project: mc
       name: Duplicate of MC-108

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -370,7 +370,7 @@ messages:
       shortcut: mvc
       message: |-
         *Thank you for your report!*
-        We're actually already tracking this issue in *MCL-14369*, so this ticket is being resolved and linked as a *duplicate*.
+        We're tracking this issue in *MCL-14369*, so this ticket is being resolved and linked as a *duplicate*.
 
         Please take a look at the Moderator Note on that ticket to see a possible solution to your issue.
         If that did not help, please join the *[Community Support Discord|https://discord.gg/58Sxm23]*.

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -367,13 +367,13 @@ messages:
   duplicate-of-mcl-14369:
     - project: mcl
       name: Duplicate of MCL-14369
-      shortcut: '14369'
+      shortcut: mvc
       message: |-
         *Thank you for your report!*
         We're actually already tracking this issue in *MCL-14369*, so this ticket is being resolved and linked as a *duplicate*.
 
         Please take a look at the Moderator Note on that ticket to see a possible solution to your issue.
-        If that did not help, please join the *[Community Support Discord|https://discord.gg/58Sxm23]* for help.
+        If that did not help, please join the *[Community Support Discord|https://discord.gg/58Sxm23]*.
 
         %quick_links%
       fillname: []


### PR DESCRIPTION
There are so many MCL-14369 reports being added every day, so I thought that I should add a helper message.

The shortcut is 'mvc' (missing version/configuration). I made a mistake in the description of one of the commits, if you're wondering why it says 'mve'. Please tell me if this shortcut is not ideal.