### PR TITLE
Fix WEB project missing in projects list

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -5,7 +5,7 @@ window.$ = window.jQuery = require('jquery');
 window.Popper = require('popper.js');
 
 // Available projects
-const projects = ["mc", "mcd", "mcl", "mcpe", "mcapi", "mce", "bds", "realms"];
+const projects = ["mc", "mcpe", "mcd", "mce", "mcl", "mcapi", "bds", "realms", "web"];
 for (const project of projects) {
   $("#projectDropdownMenu").append($(`<a class="dropdown-item ${project}-dropdown" href="#${project.toUpperCase()}">${project.toUpperCase()}</a>`));
 }

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -62,6 +62,8 @@ variables:
       value: BDS
     - project: realms
       value: REALMS
+    - project: web
+      value: WEB
 messages:
   account-issue:
     - project:


### PR DESCRIPTION
Fixes #117 (probably?)

Despite being referenced by a few messages, the WEB project is currently not part of the project list and therefore also not shown on https://mojira.github.io/helper-messages/.

Maybe it would be good to additionally add a validation step to make sure all projects referenced from `quick_links` and `messages` have an entry under `project_id`? (should I create a separate issue for that?)

Also note that currently some messages have `mctest` as project despite it being neither listed under `project_id` nor under `quick_links`. Should we remove the `mctest` references or add the missing entries for it?