### PR TITLE
Hide not-reopen-ar message

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -778,6 +778,7 @@ messages:
         - realms
         - web
       name: Not reopen AR ticket
+      hidden: true
       shortcut: hard-ar
       message: |-
         This report is currently missing crucial information. Please take a look at the other comments to find out what we are looking for.


### PR DESCRIPTION
The message tells the user that a moderator will update the report, or that the user should contact staff. Therefore it does not make sense that a staff member would use this message because they would directly interact with the user, e.g. ask them for the information.

This message only makes sense for the bot Arisa.

Though maybe I am overlooking a use case for this message?