### PR TITLE
Make message names more consistent

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -912,7 +912,7 @@ messages:
         - mcl
         - mcpe
         - realms
-      name: Panel - Removed affected version from resolved ticket
+      name: Panel - Added affected version to resolved ticket
       shortcut: remver
       message: |-
         {panel:borderColor=orange}

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -840,7 +840,7 @@ messages:
         - mctest
         - realms
         - web
-      name: Panel - Mark as private
+      name: Panel - Sensitive information
       shortcut: mkpriv
       message:
         "{panel:borderColor=orange}(!) Your bug report has been marked as _private_,
@@ -915,7 +915,7 @@ messages:
         - mctest
         - realms
         - web
-      name: Panel - Unmark private issue
+      name: Panel - Unmarked private issue
       shortcut: unpriv
       message:
         "{panel:borderColor=orange}(!) Please do not unmark issues from _private_

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -719,7 +719,7 @@ messages:
       fillname: []
   modify-entity-during-lifetime:
     - project: mc
-      name: Modify entity during lifetime
+      name: Modifying entity during lifetime
       shortcut: nbt
       message: |-
         *Thank you for your report!*


### PR DESCRIPTION
Most of the messages using imperative mood describe what the user should do, however "Panel - Mark as private" is about what the staff member / Arisa did, therefore imperative mood should not be used there. Using past tense instead might be irritating because most message names are about what the user did / should do. Therefore naming it "Marked as private" could be misundertood as something which the user did, however the action was performed by staff / Arisa.

This is similar for "Panel - Unmark private issue" as well. It describes an action the user did in the past and therefore it is more appropriate to use the past tense.