### PR TITLE
Add separate launcher log message

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -95,7 +95,7 @@ messages:
         _We do not have enough information to find the cause of this issue._
 
         Please *attach the crash report* found in {{[minecraft/crash-reports/crash-<DATE>-client.txt|https://minecrafthopper.net/help/finding-minecraft-data-folder/]}} here.
-        If you cannot find a crash report, please attach the *full launcher log* found in {{[minecraft/launcher_log.txt|https://minecrafthopper.net/help/guides/getting-minecraft-logs/]}}.
+        If you cannot find a crash report, please attach the *full launcher log* found in {{[minecraft/launcher_log.txt|https://minecrafthopper.net/help/finding-minecraft-data-folder/]}}.
 
         ~This issue is being temporarily closed as {color:#d04437}*Awaiting Response*{color}. Once the requested information has been delivered, the report will be reopened automatically.~
 
@@ -145,6 +145,21 @@ messages:
       message: |-
         *Thank you for your report!*
         Could you please include information about your server? Without it we may be unable to reproduce the issue.
+
+        %quick_links%
+      fillname: []
+  attach-launcher-log:
+    - project:
+        - mc
+        - mcl
+      name: Attach launcher log
+      shortcut: llog
+      message: |-
+        _We do not have enough information to find the cause of this issue._
+
+        Please *attach the full launcher log* found in {{[minecraft/launcher_log.txt|https://minecrafthopper.net/help/finding-minecraft-data-folder/]}}.
+
+        ~This issue is being temporarily closed as {color:#d04437}*Awaiting Response*{color}. Once the requested information has been delivered, the report will be reopened automatically.~
 
         %quick_links%
       fillname: []


### PR DESCRIPTION
Currently there is only a message for requesting a crash report and the launcher log. However for issues specific to the launcher there won't be any crash report. Therefore it would be good to have a separate message for the launcher log file.