### PR TITLE
Add message for moved issue

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1361,3 +1361,27 @@ messages:
 
         %quick_links%
       fillname: []
+  wrong-project-moved:
+    - project:
+        - bds
+        - mc
+        - mcd
+        - mce
+        - mcl
+        - mcpe
+        - realms
+      name: Wrong project (Moved)
+      shortcut: mov
+      message: |-
+        *Thank you for your report!*
+        
+        However, you have created the report for the wrong project, therefore it is being moved to the correct project. That project might require different or additional information, please check whether the report is correct and complete, *revise incorrect information and add missing information*.
+
+        These are the projects where bugs for the respective game version are tracked:
+        -- [Minecraft: Java Edition|https://bugs.mojang.com/browse/MC] --- Windows, macOS, and Linux
+        -- [Minecraft Launcher|https://bugs.mojang.com/browse/MCL] --- Bugs about the Minecraft Launcher specifically
+        -- [Minecraft (Bedrock codebase)|https://bugs.mojang.com/browse/MCPE] --- Android, iOS, Windows 10 (from the Microsoft Store), Xbox, Nintendo Switch, PlayStation, Fire OS, and Gear VR
+        -- [Minecraft Dungeons|https://bugs.mojang.com/browse/MCD] --- Action-adventure title set in the Minecraft universe
+
+        %quick_links%
+      fillname: []

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1374,7 +1374,7 @@ messages:
       message: |-
         *Thank you for your report!*
         
-        However, you have created the report for the wrong project, therefore it is being moved to the correct project. That project might require different or additional information, please check whether the report is correct and complete, *revise incorrect information and add missing information*.
+        However, you have created the report for the wrong project, therefore it is being moved to the correct project. As a result of the move, some information might have become lost or incorrect. *Please check whether the report is still correct and complete, and if necessary, edit it accordingly.*
 
         These are the projects where bugs for the respective game version are tracked:
         -- [Minecraft: Java Edition|https://bugs.mojang.com/browse/MC] --- Windows, macOS, and Linux

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1366,7 +1366,6 @@ messages:
         - bds
         - mc
         - mcd
-        - mce
         - mcl
         - mcpe
         - realms


### PR DESCRIPTION
As discussed internally we should prefer moving issues to the correct project over resolving them as invalid, since that could lead to loss of information.

However, the different projects often have different fields and require different information. Therefore it is necessary to choose default values, which might be incorrect, during moving. This pull request adds a message explaining this.

As suggested internally, the issue should not necessary be resolved as "Awaiting Response" after having been moved, because that might cause it to fall through the filters of unprocessed issues. The message therefore does not mention that the report is or will be resolved.