### PR TITLE
messages.yml: (attach-video) just like with screenshots, require the …

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -159,7 +159,7 @@ messages:
       message: |-
         _We do not have enough information to find the cause of this issue._
         
-        Please *record a video of this happening* and attach it to this report.
+        Please *record a video of this happening while the F3 debug screen is enabled* and attach it to this report.
         If you are on Windows, you can use {{Windows}}\+{{Alt}}\+{{R}} to open a built-in App for recording game footage.
         In case you don't have a program to record videos, we recommend using the free recording software [OBS|https://obsproject.com/].
         In case the resulting video file is too large to be uploaded to the bug tracker directly, please upload it elsewhere (e.g. as unlisted video on YouTube) and link to it here.


### PR DESCRIPTION
…F3 debugging screen to be enabled to eliminate the possibility of users recording videos with modified clients