### PR TITLE
Add keyboard shortcut for recording screen on Mac

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -160,8 +160,8 @@ messages:
         _We do not have enough information to find the cause of this issue._
         
         Please *record a video of this happening* and attach it to this report.
-        If you are on Windows, you can use {{Windows}}\+{{Alt}}\+{{R}} to open a built-in App for recording game footage.
-        If you are on Mac (Mojave or later), you can use {{Shift}}\+{{Command}}\+{{5}} to open a [built-in App|https://support.apple.com/guide/mac-help/take-a-screenshot-or-screen-recording-mh26782/mac] for recording your screen.
+        If you are on Windows, you can use {{Windows}}\+{{Alt}}\+{{R}} to open a built-in app for recording game footage.
+        If you are on Mac (Mojave or later), you can use {{Shift}}\+{{Command}}\+{{5}} to open a [built-in app|https://support.apple.com/guide/mac-help/take-a-screenshot-or-screen-recording-mh26782/mac] for recording your screen.
         In case you don't have a program to record videos, we recommend using the free recording software [OBS|https://obsproject.com/].
         In case the resulting video file is too large to be uploaded to the bug tracker directly, please upload it elsewhere (e.g. as unlisted video on YouTube) and link to it here.
         

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -161,6 +161,7 @@ messages:
         
         Please *record a video of this happening* and attach it to this report.
         If you are on Windows, you can use {{Windows}}\+{{Alt}}\+{{R}} to open a built-in App for recording game footage.
+        If you are on Mac (Mojave or later), you can use {{Shift}}\+{{Command}}\+{{5}} to open a [built-in App|https://support.apple.com/guide/mac-help/take-a-screenshot-or-screen-recording-mh26782/mac] for recording your screen.
         In case you don't have a program to record videos, we recommend using the free recording software [OBS|https://obsproject.com/].
         In case the resulting video file is too large to be uploaded to the bug tracker directly, please upload it elsewhere (e.g. as unlisted video on YouTube) and link to it here.
         


### PR DESCRIPTION
A keyboard shortcut for opening a screen-recording app on Mac was added to the "Attach Video (PC)" message. It is analogous to the Windows keyboard shortcut that the message already contained. Keyboard shortcuts for other operating systems were desired in #42, but the discussers weren't aware of any. In the message, I also included a link to an official Apple help page that says how to use the app.

The keyboard shortcut only works in Mojave or a later version of macOS, but according to [Statistica](https://www.statista.com/statistics/944559/worldwide-macos-version-market-share/), 71.98% of Mac users were using Mojave or a later version in June 2020. This percentage will likely increase as time goes on too.