### PR TITLE
Switch the shortcut for outdated client from 'out' to 'old'

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -751,7 +751,7 @@ messages:
   outdated-client:
     - project: mc
       name: Outdated client
-      shortcut: out
+      shortcut: old
       message: |-
         *Thank you for your report!*
         However, this issue is {color:red}*Invalid*{color}.


### PR DESCRIPTION
Fix #152 