### PR TITLE
Add message for the 1.18 experimental snapshot

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -546,6 +546,8 @@ messages:
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
         We're currently not taking bug reports for the 1.18 experiment; it is for testing the new world generation only. Please leave any new world generation-related feedback on the [feedback website|https://aka.ms/CCWorldGenFeedback].
+        
+        If you need help or support, you might like to follow a link below.
 
         %quick_links%
       fillname: []

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -536,6 +536,19 @@ messages:
         %quick_links%
       fillname:
         - Enter parent issue ID
+  experimental-snapshot:
+    - project:
+        - mc
+      name: Experimental snapshot
+      shortcut: exp
+      message: |-
+        *Thank you for your report!*
+        However, this issue is {color:#FF5722}*Invalid*{color}.
+
+        We're currently not taking bug reports for the 1.18 experiment; it is for testing the new world generation only. Please leave any new world generation-related feedback on the [feedback website|https://aka.ms/CCWorldGenFeedback].
+
+        %quick_links%
+      fillname: []
   external-server-issue:
     - project:
         - bds

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -545,7 +545,7 @@ messages:
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
-        We're currently not taking bug reports for the 1.18 experiment; it is for testing the new world generation only. Please leave any new world generation-related feedback on the [feedback website|https://aka.ms/CCWorldGenFeedback].
+        We're currently not taking bug reports for the 1.18 experiment; it is for testing the new world generation only. Please leave any new world generation-related feedback on the [reddit post|https://www.reddit.com/r/Minecraft/comments/ojio1q/minecraft_118_experimental_snapshot_is_out/] or on the [feedback website|https://aka.ms/CCWorldGenFeedback].
         
         If you need help or support, you might like to follow a link below.
 


### PR DESCRIPTION
Fixes #159 by adding the following message for the 1.18 snapshots:

> **Thank you for your report!**
        However, this issue is **Invalid**.
        We're currently not taking bug reports for the 1.18 experiment; it is for testing the new world generation only. Please leave any new world generation-related feedback on the [reddit post](https://www.reddit.com/r/Minecraft/comments/ojio1q/minecraft_118_experimental_snapshot_is_out/) or on the [feedback website](https://aka.ms/CCWorldGenFeedback).
> 
> If you need help or support, you might like to follow a link below.
> 
> (Quick links)

Feel free to change anything.