### PR TITLE
Add duplicate-invalid message

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -350,6 +350,29 @@ messages:
         %quick_links%
       fillname:
         - Enter parent issue ID
+  duplicate-invalid:
+    - project:
+        - bds
+        - mc
+        - mcd
+        - mcl
+        - mcpe
+        - mctest
+        - realms
+        - web
+      name: Duplicate (tech support)
+      shortcut: idup
+      message: |-
+        *Thank you for your report!*
+        We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
+
+        That ticket has already been resolved as invalid. Please take a look at the parent ticket (%s%) and see if an explanation is provided there.
+
+        If you haven't already, you might like to make use of the [*+search feature+*|https://bugs.mojang.com/issues/?jql=project=%project_id%] to see if the issue has already been mentioned.
+
+        %quick_links%
+      fillname:
+        - Enter parent issue ID
   duplicate-of-mc-128302:
     - project:
         - mc


### PR DESCRIPTION
This message is more general than `duplicate-tech` and can be used for tech support, account issues, modified games, and user errors.