### PR TITLE
Add message for legacy launcher version

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -715,6 +715,19 @@ messages:
 
         %quick_links%
       fillname: []
+  legacy-launcher-version:
+    - project: mcl
+      name: Legacy launcher version
+      shortcut: leg
+      message: |-
+        You have selected the version "1.6.93 (legacy)" as affected version for your report. Nowadays most users are using the new native launcher.
+        If the launcher you are using has a big green "PLAY" button for starting the game, then you are using the new launcher. To find out the version you are using, please click on "Settings" in the lower left corner, then open the "About" tab. Right below "Launcher" it shows the version of the launcher.
+        Please update the affected versions of your report by removing "1.6.93 (legacy)" and choosing the correct version.
+
+        In case you are actually using the legacy launcher, consider switching to the new native launcher. It can be downloaded [here|https://www.minecraft.net/download/alternative].
+
+        %quick_links%
+      fillname: []
   minimum-requirements-not-met:
     - project:
         - mc


### PR DESCRIPTION
It appears many MCL reports choosing "1.6.93 (legacy)" as affected version are actually for the new native launcher, see [query](https://bugs.mojang.com/issues/?jql=project%20%3D%20MCL%20and%20affectedVersion%20%3D%20%221.6.93%20(legacy)%22%20order%20by%20createdDate).

The new message informs the user that they should check whether they are actually using the legacy launcher.
The message does not mention that the report will be resolved (e.g. as Awaiting Response) so it can be used by Arisa in the future, when a report might indeed be for the legacy launcher and should therefore not be resolved.

----

Credits go to @dericksonmark who raised internally a related problem with the "1.6.93 (legacy)" version.
