### PR TITLE
Update Reddit link in experimental snapshot message

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -545,7 +545,7 @@ messages:
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
-        We're currently not taking bug reports for the 1.18 experiment; it is for testing the new world generation only. Please leave any new world generation-related feedback on the [reddit post|https://www.reddit.com/r/Minecraft/comments/ojio1q/minecraft_118_experimental_snapshot_is_out/] or on the [feedback website|https://aka.ms/CCWorldGenFeedback].
+        We're currently not taking bug reports for the 1.18 experiment; it is for testing the new world generation only. Please leave any new world generation-related feedback on the [reddit post|https://www.reddit.com/r/Minecraft/comments/p1pc9d/minecraft_118_experimental_snapshot_3_is_out/] or on the [feedback website|https://aka.ms/CCWorldGenFeedback].
         If you experience this issue in the latest 1.17 release please search for existing reports. If you did not find one, create a new report with 1.17 as the affected version.
 
         If you need help or support, you might like to follow a link below.


### PR DESCRIPTION
With the release of 1.18 Experimental Snapshot 3, a new Reddit post was created, asking users to comment on this newer Reddit post with bugs and feedback. This should be updated in the helper message.