### PR TITLE
Add message for invalid unspecific performance issue

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -740,6 +740,35 @@ messages:
 
         %quick_links%
       fillname: []
+  invalid-unspecific-lag:
+    - project:
+        - mc
+      name: Invalid unspecific lag
+      shortcut: lag
+      message: |-
+        *Thank you for your report!*
+        However, this issue is {color:#FF5722}*Invalid*{color}.
+
+        Performance drops are expected to happen between versions, especially in snapshots. Simply stating that "My game is laggier" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
+
+        Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues. To learn more about this, head [here|https://www.minecraft.net/en-us/article/minecraft-snapshot-21w38a] (section "Telemetry") for more information.
+
+        %quick_links%
+      fillname: []
+    - project:
+        - mcpe
+      name: Invalid unspecific lag
+      shortcut: lag
+      message: |-
+        *Thank you for your report!*
+        However, this issue is {color:#FF5722}*Invalid*{color}.
+
+        Performance drops are expected to happen between versions, especially in betas. Simply stating that "My game is laggier" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
+
+        Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues.
+
+        %quick_links%
+      fillname: []
   legacy-launcher-version:
     - project: mcl
       name: Legacy launcher version


### PR DESCRIPTION
Resolves #175

Includes the message from #175 with some changes:
- Adjusted formatting to be consistent with other messages (e.g. `{color...}` usage)
- Adjusted phrase to "contact Community Support", see also #126
- Removed "is not <del>helpful for the bug tracker and</del> for Mojang to diagnose your issue".
"helpful for the bug tracker" sounds rather abstract / unspecific; but I can add it again if you want
- Changed "If you can <del>diagnose</del> <ins>pinpoint</ins> a specific cause". The previous sentense talks about Mojang diagnosing the issue; maybe that could be misunderstood that we have really high (technical) expectations on the report. But if you want I can revert this change again.
- Split message into Bedrock and Java version:
  - Bedrock version uses "betas"
  - Java version uses "snapshots"
  - Only Java version refers to 21w38a blog post (and added reference to "Telemetry" section); for Bedrock there does not appear to be a fitting help page / blog post?

@Thumpbacker, I added you as reviewer because you are the original author, but feedback from others is appreciated as well 🙂