### PR TITLE
Add message for crash from modded world

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -868,8 +868,8 @@ messages:
       message: |-
         The attached crash report indicates that you had opened your world with a 'modded' game in the past.
         We only accept reports about the unmodified ('vanilla') game here on the bug tracker. To rule out that the modified game is responsible for the crash,
-        please try reproducing this issue with a newly created world or a world which had not been opened with a modified game in the past. If you experience
-        the crash there as well please attach that crash report too. Otherwise please report this issue to the author of the modification instead.
+        please try reproducing this issue with a newly created world or a world that has not been opened with a modified game in the past. If you experience
+        the crash there as well, please attach that crash report too. Otherwise, please report this issue to the author of the modification instead.
 
         %quick_links%
       fillname: []

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -858,6 +858,21 @@ messages:
 
         %quick_links%
       fillname: []
+  modified-world-crash:
+    - project:
+        - mc
+        - mcl
+        - mctest
+      name: Modified world crash
+      shortcut: worldmod
+      message: |-
+        The attached crash report indicates that you had opened your world with a 'modded' game in the past.
+        We only accept reports about the unmodified ('vanilla') game here on the bug tracker. To rule out that the modified game is responsible for the crash,
+        please try reproducing this issue with a newly created world or a world which had not been opened with a modified game in the past. If you experience
+        the crash there as well please attach that crash report too. Otherwise please report this issue to the author of the modification instead.
+
+        %quick_links%
+      fillname: []
   multiple-issues-in-one-report:
     - project:
         - bds

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -864,7 +864,7 @@ messages:
         - mcl
         - mctest
       name: Modified world crash
-      shortcut: worldmod
+      shortcut: mworld
       message: |-
         The attached crash report indicates that you had opened your world with a 'modded' game in the past.
         We only accept reports about the unmodified ('vanilla') game here on the bug tracker. To rule out that the modified game is responsible for the crash,


### PR DESCRIPTION
Draft for a new message when a crash report indicates that a world had been opened with a modded game in the past (`Level was modded: true`). For manual usage, and possibly in the future also for usage by Arisa.

Intentionally does not mention that report is Invalid or that it will be resolved as Awaiting Response because, as discussed internally, a crash report might still be valid even though the world had been opened with a modded game in the past.

See also https://github.com/urielsalis/mc-crash-lib/pull/21