### PR TITLE
Update messages.yml

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -735,7 +735,7 @@ messages:
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
-       Simply stating that "My game is laggy" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
+        Simply stating that "My game is laggy" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
 
         Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues. To learn more about this, head [here|https://www.minecraft.net/en-us/article/minecraft-snapshot-21w38a] (section "Telemetry") for more information.
 

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -749,7 +749,7 @@ messages:
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
-        Performance drops are expected to happen between versions, especially in betas. Simply stating that "My game is laggier" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
+        Simply stating that "My game is laggy" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
 
         Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues.
 

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -735,7 +735,7 @@ messages:
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
-        Performance drops are expected to happen between versions, especially in snapshots. Simply stating that "My game is laggier" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
+       Simply stating that "My game is laggy" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
 
         Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues. To learn more about this, head [here|https://www.minecraft.net/en-us/article/minecraft-snapshot-21w38a] (section "Telemetry") for more information.
 


### PR DESCRIPTION
Saying that performance drops are expected between versions is not helpful, and probably not true. Though it might be possible to generalize to say that for preview/beta, IMO it is simpler to get rid of that statement.

I did not update the java message, but that would be simple to do also.