### PR TITLE
Categorize messages in dropdown menu

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -89,6 +89,9 @@ $("#copybutton").click(function () {
   let messageBody = getStringValue(message.message);
   // Replace predefined variables in the message body
   for (const variable in variables) {
+    if (!variables[variable][0]?.project) {
+      continue;
+    }
     for (const { project: expected, value } of variables[variable]) {
       if (isExpectedProject(expected, project)) {
         messageBody = messageBody.replace(new RegExp(`%${variable}%`, 'g'), getStringValue(value));

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -17,11 +17,15 @@ var project = "mc";
 // Currently selected message code
 var code = "-1";
 
-// map for messages sorted by their categories
-var categoryMap = new Map();
-
 // map for dropdown values and their corresponding messages
 var dropdownMap = new Map();
+
+// map for category keys and their corresponding names
+var categoryMap = new Map();
+
+for (const {category, name} of categories) {
+  categoryMap.set(category, name);
+}
 
 /**
  * Main app entry point
@@ -187,8 +191,8 @@ function getStringValue(val) {
 function updateDisplay() {
   var text = '<option value="-1">Select a message...</option>';
   var selected = false;
-  // Clear category map
-  categoryMap = new Map();
+  // Create a map for categorized messages
+  var messageMap = new Map();
   // Clear dropdown map
   dropdownMap = new Map();
   // Set project dropdown title
@@ -203,22 +207,23 @@ function updateDisplay() {
         if (i == code) {
           selected = true;
         }
-        var catText = categoryMap.get(messageArray[j].category);
+        var catText = messageMap.get(messageArray[j].category);
         var option = `<option value="${i}"${i == code ? ' selected': ''}>` + messageArray[j].name + '</option>';
         // Append option to category
         catText = !catText ? option : catText + option;
-        categoryMap.set(messageArray[j].category, catText);
+        messageMap.set(messageArray[j].category, catText);
         // Map message to dropdown ID for later recognition
         dropdownMap.set(i, messageArray[j]);
       }
     }
   }
 
+  // Sort categorized messages alphabetically
+  messageMap = new Map([...messageMap].sort());
+
   // Format dropdown menu labels
-  for (const {category, value} of categories) {
-    if (categoryMap.has(category)) {
-      text += `<optgroup label="${value}">${categoryMap.get(category)}</optgroup>`
-    }
+  for (const [category, options] of messageMap.entries()) {
+    text += `<optgroup label="${categoryMap.get(category) || category}">${options}</optgroup>`
   }
 
   // Update dropdown HTML

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,5 +1,5 @@
 // ES6 imports
-let { messages, variables } = require('./messages.json');
+let { messages, variables, categories } = require('./messages.json');
 window.bootstrap = require('bootstrap');
 window.$ = window.jQuery = require('jquery');
 window.Popper = require('popper.js');
@@ -218,9 +218,9 @@ function updateDisplay() {
   }
 
   // Format dropdown menu labels
-  for (const category of variables.categories) {
-    if (categoryMap.get(category.category)) {
-      text += `<optgroup label="${category.value}">${categoryMap.get(category.category)}</optgroup>`
+  for (const {category, value} of categories) {
+    if (categoryMap.has(category)) {
+      text += `<optgroup label="${value}">${categoryMap.get(category)}</optgroup>`
     }
   }
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -17,6 +17,9 @@ var project = "mc";
 // Currently selected message code
 var code = "-1";
 
+// map for messages sorted by their categories
+var categoryMap = new Map();
+
 // map for dropdown values and their corresponding messages
 var dropdownMap = new Map();
 
@@ -184,6 +187,8 @@ function getStringValue(val) {
 function updateDisplay() {
   var text = '<option value="-1">Select a message...</option>';
   var selected = false;
+  // Clear category map
+  categoryMap = new Map();
   // Clear dropdown map
   dropdownMap = new Map();
   // Set project dropdown title
@@ -198,10 +203,21 @@ function updateDisplay() {
         if (i == code) {
           selected = true;
         }
-        text += `<option value="${i}" ${i == code ? 'selected': ''}>` + messageArray[j].name + '</option>';
+        var catText = categoryMap.get(messageArray[j].category);
+        var option = `<option value="${i}"${i == code ? ' selected': ''}>` + messageArray[j].name + '</option>';
+        // Append option to category
+        catText = !catText ? option : catText + option;
+        categoryMap.set(messageArray[j].category, catText);
         // Map message to dropdown ID for later recognition
         dropdownMap.set(i, messageArray[j]);
       }
+    }
+  }
+
+  // Format dropdown menu labels
+  for (const category of variables.categories) {
+    if (categoryMap.get(category.category)) {
+      text += `<optgroup label="${category.value}">${categoryMap.get(category.category)}</optgroup>`
     }
   }
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -89,9 +89,6 @@ $("#copybutton").click(function () {
   let messageBody = getStringValue(message.message);
   // Replace predefined variables in the message body
   for (const variable in variables) {
-    if (!variables[variable][0]?.project) {
-      continue;
-    }
     for (const { project: expected, value } of variables[variable]) {
       if (isExpectedProject(expected, project)) {
         messageBody = messageBody.replace(new RegExp(`%${variable}%`, 'g'), getStringValue(value));

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -50,6 +50,17 @@ variables:
       value: REALMS
     - project: web
       value: WEB
+  categories:
+    - category: duplicate
+      value: Duplicate
+    - category: invalid
+      value: Invalid
+    - category: ar
+      value: Awaiting Response
+    - category: notice
+      value: Panels / Notices
+    - category: misc
+      value: Miscellaneous
 messages:
   account-issue:
     - project:
@@ -62,6 +73,7 @@ messages:
         - web
       name: Account/billing issue
       shortcut: acc
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color} for the bug tracker.
@@ -77,6 +89,7 @@ messages:
         - mcl
       name: Attach crash report
       shortcut: crash
+      category: ar
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -91,6 +104,7 @@ messages:
     - project: mc
       name: Attach F3 debug screenshot
       shortcut: f3screen
+      category: ar
       message: |-
         Please attach a screenshot of this occurring while the F3 debug screen is enabled.
 
@@ -102,6 +116,7 @@ messages:
     - project: mc
       name: Attach profiling report
       shortcut: prof
+      category: ar
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -119,6 +134,7 @@ messages:
     - project: bds
       name: Attach server information
       shortcut: server
+      category: ar
       message: |-
         *Thank you for your report!*
         Could you please include information about your server? Without it we may be unable to reproduce the issue.
@@ -131,6 +147,7 @@ messages:
         - mcl
       name: Attach launcher log
       shortcut: llog
+      category: ar
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -148,6 +165,7 @@ messages:
         - mcd
       name: Attach video (PC)
       shortcut: vid
+      category: ar
       message: |-
         _We do not have enough information to find the cause of this issue._
         
@@ -165,6 +183,7 @@ messages:
         - mcpe
       name: Attach video (Mobile)
       shortcut: mvid
+      category: ar
       message: |-
         _We do not have enough information to find the cause of this issue._
         
@@ -181,6 +200,7 @@ messages:
         - mcl
       name: Attach world file
       shortcut: world
+      category: ar
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -194,6 +214,7 @@ messages:
     - project: mc
       name: Auth server down
       shortcut: auth
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -211,6 +232,7 @@ messages:
         - web
       name: Banned
       shortcut: ban
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -224,6 +246,7 @@ messages:
     - project: mc
       name: Combat Test
       shortcut: combat
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -241,6 +264,7 @@ messages:
         - realms
       name: Crash logged automatically
       shortcut: autocrash
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color} for the bug tracker.
@@ -254,6 +278,7 @@ messages:
     - project: mcd
       name: Crash logged automatically
       shortcut: autocrash
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -268,6 +293,7 @@ messages:
     - project: mc
       name: Debug Stick
       shortcut: stick
+      category: misc
       message: |-
         *Thank you for your report!*
         However, this issue won't be fixed.
@@ -283,6 +309,7 @@ messages:
         - web
       name: Demo account
       shortcut: demo
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -304,6 +331,7 @@ messages:
         - web
       name: Duplicate
       shortcut: dup
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -327,6 +355,7 @@ messages:
         - web
       name: Duplicate (fixed)
       shortcut: fdup
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -350,6 +379,7 @@ messages:
         - web
       name: Duplicate (invalid)
       shortcut: idup
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -367,6 +397,7 @@ messages:
         - mcl
       name: Duplicate of MC-128302
       shortcut: ogl
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *MC-128302*, so this ticket is being resolved and linked as a *duplicate*.
@@ -382,6 +413,7 @@ messages:
     - project: mc
       name: Duplicate of MC-297
       shortcut: '297'
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *MC-297*, so this ticket is being resolved and linked as a *duplicate*.
@@ -397,6 +429,7 @@ messages:
     - project: mcl
       name: Duplicate of MCL-5638
       shortcut: jre
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *MCL-5638*, so this ticket is being resolved and linked as a *duplicate*.
@@ -410,6 +443,7 @@ messages:
     - project: mcl
       name: Duplicate of MCL-14369
       shortcut: mvc
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *MCL-14369*, so this ticket is being resolved and linked as a *duplicate*.
@@ -423,6 +457,7 @@ messages:
     - project: mc
       name: Duplicate of MC-108
       shortcut: quasi
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *MC-108*, so this ticket is being resolved and linked as a *duplicate*.
@@ -445,6 +480,7 @@ messages:
         - web
       name: Duplicate (private)
       shortcut: pdup
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%* (private), so this ticket is being resolved and linked as a *duplicate*.
@@ -466,6 +502,7 @@ messages:
         - web
       name: Duplicate (tech support)
       shortcut: tdup
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -490,6 +527,7 @@ messages:
         - web
       name: Duplicate (wai)
       shortcut: wdup
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -513,6 +551,7 @@ messages:
         - web
       name: Duplicate (won't fix)
       shortcut: wfdup
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're tracking this issue as *%s%*, so this ticket is being resolved and linked as a *duplicate*.
@@ -538,6 +577,7 @@ messages:
         - web
       name: Duplicate (forward)
       shortcut: fodup
+      category: duplicate
       message: |-
         *Thank you for your report!*
         We're resolving and linking this ticket forward as a *duplicate* of *%s%*, as that ticket contains more detailed information and/or has already been triaged by Mojang.
@@ -552,6 +592,7 @@ messages:
         - mc
       name: Experimental snapshot
       shortcut: exp
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -569,6 +610,7 @@ messages:
         - mcpe
       name: External server issue
       shortcut: ext
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -589,6 +631,7 @@ messages:
         - realms
       name: Feature request
       shortcut: feat
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -610,6 +653,7 @@ messages:
         - web
       name: Attach new attachment
       shortcut: attachnew
+      category: misc
       message: |-
         An attachment with a disallowed file extension has been removed from this ticket.
 
@@ -622,6 +666,7 @@ messages:
         - mcl
       name: Force debug crash report
       shortcut: force
+      category: ar
       message: |-
         _We do not have enough information to find the cause of this issue._
 
@@ -635,6 +680,7 @@ messages:
     - project: mcpe
       name: Hashtag issue
       shortcut: hashtag
+      category: misc
       message:
         For any new or ongoing hashtag issues, please create a new ticket for
         any gamertags still affected and use the label {{[chat-filter|https://bugs.mojang.com/issues/?jql=labels+%3D+chat-filter]}}.
@@ -681,6 +727,7 @@ messages:
         - mctest
       name: Incomplete
       shortcut: inc
+      category: misc
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Incomplete*{color}.
@@ -700,6 +747,7 @@ messages:
         - web
       name: Incomplete
       shortcut: inc
+      category: misc
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Incomplete*{color}.
@@ -717,6 +765,7 @@ messages:
         - mcl
       name: MCL-6550 tech support issue
       shortcut: resp
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -731,6 +780,7 @@ messages:
         - mc
       name: Invalid unspecific lag
       shortcut: lag
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -745,6 +795,7 @@ messages:
         - mcpe
       name: Invalid unspecific lag
       shortcut: lag
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -759,6 +810,7 @@ messages:
     - project: mcl
       name: Legacy launcher version
       shortcut: leg
+      category: notice
       message: |-
         You have selected the version "1.6.93 (legacy)" as affected version for your report. Nowadays most users are using the new native launcher.
         If the launcher you are using has a big green "PLAY" button for starting the game, then you are using the new launcher. To find out the version you are using, please click on "Settings" in the lower left corner, then open the "About" tab. Right below "Launcher" it shows the version of the launcher.
@@ -772,6 +824,7 @@ messages:
     - project: mcpe
       name: Marketplace content bug
       shortcut: market
+      category: invalid
       message: |-
         *Thank you for your report!* 
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -787,6 +840,7 @@ messages:
         - mcl
       name: Minimum requirements not met
       shortcut: min
+      category: invalid
       message: |-
         *Thank you for your report!* 
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -799,6 +853,7 @@ messages:
         - mcd
       name: Minimum requirements not met
       shortcut: min
+      category: invalid
       message: |-
         *Thank you for your report!* 
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -814,6 +869,7 @@ messages:
         - mctest
       name: Modified game
       shortcut: mod
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -832,6 +888,7 @@ messages:
         - mcpe
       name: Modified game
       shortcut: mod
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -849,6 +906,7 @@ messages:
     - project: mc
       name: Modifying entity during lifetime
       shortcut: nbt
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -865,6 +923,7 @@ messages:
         - mctest
       name: Modified world crash
       shortcut: mworld
+      category: ar
       message: |-
         The attached crash report indicates that you had opened your world with a 'modded' game in the past.
         We only accept reports about the unmodified ('vanilla') game here on the bug tracker. To rule out that the modified game is responsible for the crash,
@@ -883,6 +942,7 @@ messages:
         - realms
       name: Multiple issues in one report
       shortcut: mult
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -913,6 +973,7 @@ messages:
     - project: mc
       name: Outdated client
       shortcut: old
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -936,6 +997,7 @@ messages:
         - web
       name: Panel - Environment Desc.
       shortcut: env
+      category: notice
       message:
         "{panel:borderColor=orange}(!) The environment is supposed to only contain
         PC details.{panel}"
@@ -947,6 +1009,7 @@ messages:
         - mcpe
       name: Panel - Future Version
       shortcut: fut-old
+      category: notice
       message:
         "{panel:borderColor=orange}(!) Please do not mark _Unreleased Versions_
         as affected. You don't have access to them yet.{panel}"
@@ -963,6 +1026,7 @@ messages:
         - web
       name: Panel - Sensitive information
       shortcut: mkpriv
+      category: notice
       message:
         "{panel:borderColor=orange}(!) Your bug report has been marked as _private_,
         as it contains some sensitive privacy information (e.g. an email address or session ID).{panel}"
@@ -979,6 +1043,7 @@ messages:
         - web
       name: Panel - Mojang Priority
       shortcut: prio
+      category: notice
       message:
         '{panel:borderColor=orange}(!) Don''t try to change "Mojang Priority".
         It may only be changed by the developers. Consider this a warning.{panel}'
@@ -995,6 +1060,7 @@ messages:
         - web
       name: Panel - Note
       shortcut: note
+      category: notice
       message: |-
         {panel:title=Note|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}
         %s%
@@ -1013,6 +1079,7 @@ messages:
         - web
       name: Panel - Private issue
       shortcut: priv
+      category: notice
       message:
         "{panel:borderColor=orange}(!) Please do not mark issues as _private_,
         unless your bug report is an exploit or contains information about your username
@@ -1028,6 +1095,7 @@ messages:
         - realms
       name: Panel - Added affected version to resolved ticket
       shortcut: remver
+      category: notice
       message: |-
         {panel:borderColor=orange}
         (!) Please do not add Affected Versions to resolved reports.
@@ -1047,6 +1115,7 @@ messages:
         - web
       name: Panel - Unmarked private issue
       shortcut: unpriv
+      category: notice
       message:
         "{panel:borderColor=orange}(!) Please do not unmark issues from _private_
         after a moderator had set it that way.{panel}"
@@ -1063,6 +1132,7 @@ messages:
         - web
       name: Panel - Workaround
       shortcut: workaround
+      category: notice
       message: |-
         {panel:title=Workaround|borderStyle=dashed|borderColor=#ccc|titleBGColor=#C1F7D6|bgColor=#CEFFFF}
         %s%
@@ -1076,6 +1146,7 @@ messages:
         - realms
       name: Parity issue
       shortcut: parity
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -1095,6 +1166,7 @@ messages:
         - mcl
       name: Pirated Minecraft
       shortcut: pir
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -1115,6 +1187,7 @@ messages:
         - realms
       name: Provide affected versions
       shortcut: fut
+      category: ar
       message: |-
         {panel:borderColor=orange}(!) Please do not mark _Unreleased Versions_ as affected. You don't have access to them yet.{panel}
         
@@ -1135,6 +1208,7 @@ messages:
         - mc
       name: Provide seed and coordinates
       shortcut: loc
+      category: ar
       message: |-
         _We do not have enough information to reproduce this issue._
 
@@ -1164,6 +1238,7 @@ messages:
         - web
       name: Quick links
       shortcut: qul
+      category: misc
       message: "%quick_links%"
       fillname: []
   report-not-in-english:
@@ -1177,6 +1252,7 @@ messages:
         - web
       name: Report not in English
       shortcut: lang
+      category: invalid
       message: |-
         *Thank you for your report!*
         Thank you for taking the time to report a bug. Unfortunately we are only able to accept bug reports in English since it is the common language used on this tracker.
@@ -1227,6 +1303,7 @@ messages:
         - web
       name: Technical support issue
       shortcut: tech
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -1245,6 +1322,7 @@ messages:
         - realms
       name: Temporary Service Outage
       shortcut: outage
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -1264,6 +1342,7 @@ messages:
     - project: mc
       name: Translation issue
       shortcut: trans
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -1276,6 +1355,7 @@ messages:
     - project: mcl
       name: Translation issue
       shortcut: trans
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -1289,6 +1369,7 @@ messages:
     - project: mc
       name: Works As Intended
       shortcut: wai
+      category: misc
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Working as Intended*{color}.
@@ -1306,6 +1387,7 @@ messages:
     - project: mcpe
       name: Works As Intended
       shortcut: wai
+      category: misc
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Working as Intended*{color}.
@@ -1323,6 +1405,7 @@ messages:
     - project: mcl
       name: Works As Intended
       shortcut: wai
+      category: misc
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Working as Intended*{color}.
@@ -1347,6 +1430,7 @@ messages:
         - realms
       name: Wrong project
       shortcut: proj
+      category: invalid
       message: |-
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
@@ -1371,6 +1455,7 @@ messages:
         - realms
       name: Wrong project (Moved)
       shortcut: mov
+      category: notice
       message: |-
         *Thank you for your report!*
         

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1,3 +1,14 @@
+categories:
+  - category: duplicate
+    value: Duplicate
+  - category: invalid
+    value: Invalid
+  - category: ar
+    value: Awaiting Response
+  - category: notice
+    value: Panels / Notices
+  - category: misc
+    value: Miscellaneous
 variables:
   quick_links:
     - project: bds
@@ -50,17 +61,6 @@ variables:
       value: REALMS
     - project: web
       value: WEB
-  categories:
-    - category: duplicate
-      value: Duplicate
-    - category: invalid
-      value: Invalid
-    - category: ar
-      value: Awaiting Response
-    - category: notice
-      value: Panels / Notices
-    - category: misc
-      value: Miscellaneous
 messages:
   account-issue:
     - project:

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1,14 +1,14 @@
 categories:
   - category: duplicate
-    value: Duplicate
+    name: Duplicate
   - category: invalid
-    value: Invalid
+    name: Invalid
   - category: ar
-    value: Awaiting Response
+    name: Awaiting Response
   - category: notice
-    value: Panels / Notices
+    name: Panels / Notices
   - category: misc
-    value: Miscellaneous
+    name: Miscellaneous
 variables:
   quick_links:
     - project: bds

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -698,6 +698,7 @@ messages:
       name: I am a Bot
       hidden: true
       shortcut: bot
+      category: misc
       message:
         "~{color:#888}-- I am a bot. This action was performed automatically!
         If you think it was incorrect, please notify us
@@ -716,6 +717,7 @@ messages:
       name: I am a Bot duplicate message
       hidden: true
       shortcut: bot-dup
+      category: misc
       message:
         "~{color:#888}-- I am a bot. This action was performed automatically!
         The ticket was resolved by one of our moderators, and I left this message to give more information to you.{color}~"
@@ -965,6 +967,7 @@ messages:
       name: Not reopen AR ticket
       hidden: true
       shortcut: hard-ar
+      category: notice
       message: |-
         This report is currently missing crucial information. Please take a look at the other comments to find out what we are looking for.
         If you added the required information and a moderator sees your comment, they will reopen and update the report. However, if you think your update to this report has been overlooked or you want to make sure that this report is reopened, you can contact the Mojira staff on [Discord|https://discordapp.com/invite/rpCyfKV] or [Reddit|https://www.reddit.com/r/Mojira/].
@@ -1277,6 +1280,7 @@ messages:
       name: Report not in English (Bot)
       hidden: true
       shortcut: lang-bot
+      category: invalid
       message: |-
         *Thank you for your report!*
         We appreciate you taking the time to report a bug. Unfortunately we are only able to accept bug reports in English, since it is the common language used by Mojang Studios and on this bug tracker.

--- a/messages_schema.json
+++ b/messages_schema.json
@@ -2,6 +2,27 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
+        "categories": {
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "category": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "category",
+                        "value"
+                    ]
+                }
+            }
+        },
         "variables": {
             "additionalProperties": {
                 "type": "array",
@@ -12,9 +33,6 @@
                         "project": {
                             "$ref": "#/definitions/projectFilter"
                         },
-                        "category": {
-                            "$ref": "#/definitions/categoryFilter"
-                        },
                         "value": {
                             "type": "string"
                         },
@@ -22,19 +40,8 @@
                             "$ref": "#/definitions/localizedValues"
                         }
                     },
-                    "oneOf": [
-                        {
-                            "required": [
-                                "project"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "category"
-                            ]
-                        }
-                    ],
                     "required": [
+                        "project",
                         "value"
                     ]
                 }
@@ -106,9 +113,6 @@
                     }
                 }
             ]
-        },
-        "categoryFilter": {
-            "type": "string"
         },
         "localizedValues": {
             "type": "object",

--- a/messages_schema.json
+++ b/messages_schema.json
@@ -12,13 +12,13 @@
                         "category": {
                             "type": "string"
                         },
-                        "value": {
+                        "name": {
                             "type": "string"
                         }
                     },
                     "required": [
                         "category",
-                        "value"
+                        "name"
                     ]
                 }
             }

--- a/messages_schema.json
+++ b/messages_schema.json
@@ -12,6 +12,9 @@
                         "project": {
                             "$ref": "#/definitions/projectFilter"
                         },
+                        "category": {
+                            "$ref": "#/definitions/categoryFilter"
+                        },
                         "value": {
                             "type": "string"
                         },
@@ -19,8 +22,19 @@
                             "$ref": "#/definitions/localizedValues"
                         }
                     },
+                    "oneOf": [
+                        {
+                            "required": [
+                                "project"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "category"
+                            ]
+                        }
+                    ],
                     "required": [
-                        "project",
                         "value"
                     ]
                 }
@@ -41,6 +55,9 @@
                         },
                         "hidden": {
                             "type": "boolean"
+                        },
+                        "category": {
+                            "type": "string"
                         },
                         "message": {
                             "type": "string"
@@ -64,6 +81,7 @@
                         "project",
                         "name",
                         "shortcut",
+                        "category",
                         "message",
                         "fillname"
                     ]
@@ -88,6 +106,9 @@
                     }
                 }
             ]
+        },
+        "categoryFilter": {
+            "type": "string"
         },
         "localizedValues": {
             "type": "object",


### PR DESCRIPTION
## The change
Categories! I've added categories for duplicates, invalids, ARs, panels/notices, and miscellaneous items. [Here](https://user-images.githubusercontent.com/68699877/178896236-f6483ea7-6d8e-4f78-b809-042994957a51.png)'s a sample.
Feedback is, of course, welcome, for both the code changes and the categories. This implements #97. Thank you! :)
## How this affects future messages
This change requires a category field in every message definition. Additional categories can be configured within the `variables` section, and messages with undefined categories will not be shown in the dropdown menu.