### PR TITLE
Add message for attaching game log

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -81,7 +81,8 @@ messages:
         _We do not have enough information to find the cause of this issue._
 
         Please *attach the crash report* found in {{[minecraft/crash-reports/crash-<DATE>-client.txt|https://minecrafthopper.net/help/finding-minecraft-data-folder/]}} here.
-        If you cannot find a crash report, please attach the *full launcher log* found in {{[minecraft/launcher_log.txt|https://minecrafthopper.net/help/finding-minecraft-data-folder/]}}.
+        If you cannot find a crash report, please attach the *full launcher log* found in {{[minecraft/launcher_log.txt|https://minecrafthopper.net/help/finding-minecraft-data-folder/]}} and *the full game log* found in {{logs/latest.log}}. By default this {{logs}} folder is also in the [{{minecraft}} data folder|https://minecrafthopper.net/help/finding-minecraft-data-folder/], unless you have specified a custom game directory in the launcher.
+        If the issue occurred a few days ago please attach the corresponding {{.log.gz}} archive, for example {{2022-07-01-1.log.gz}}.
 
         ~This issue is being temporarily closed as {color:#d04437}*Awaiting Response*{color}. Once the requested information has been delivered, the report will be reopened automatically.~
 
@@ -122,6 +123,22 @@ messages:
       message: |-
         *Thank you for your report!*
         Could you please include information about your server? Without it we may be unable to reproduce the issue.
+
+        %quick_links%
+      fillname: []
+  attach-game-log:
+    - project:
+        - mc
+        - mcl
+      name: Attach game log
+      shortcut: glog
+      message: |-
+        _We do not have enough information to find the cause of this issue._
+
+        Please *attach the full game log* found in {{logs/latest.log}}. By default this {{logs}} folder is in the [{{minecraft}} data folder|https://minecrafthopper.net/help/finding-minecraft-data-folder/], unless you have specified a custom game directory in the launcher.
+        If the issue occurred a few days ago please attach the corresponding {{.log.gz}} archive, for example {{2022-07-01-1.log.gz}}.
+
+        ~This issue is being temporarily closed as {color:#d04437}*Awaiting Response*{color}. Once the requested information has been delivered, the report will be reopened automatically.~
 
         %quick_links%
       fillname: []


### PR DESCRIPTION
Also resolves #133

Any feedback is appreciated!

Have marked this as Draft for now because I am not sure if we should use the MinecraftHopper articles for [getting the latest logs](https://minecrafthopper.net/help/guides/getting-minecraft-latest-log/) or [copying the game output](https://minecrafthopper.net/help/guides/getting-minecraft-game-output-log/).
Both currently recommend to use https://paste.gg/ and to include the Discord username, which probably overcomplicates it for our Mojira usecase. Additionally copying the game output directly from the launcher window seems a bit error-prone to me. What do you think?