### PR TITLE
Fix switching projects not properly updating message information

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -583,9 +583,7 @@ messages:
     - project:
         - bds
         - mc
-        - mcapi
         - mcd
-        - mce
         - mcl
         - mcpe
         - mctest


### PR DESCRIPTION
Resolves #69

The problem was that `updateDisplay()` only had logic to show the "Please select a message." text and disable the "Copy" button if no message is selected, but did not have logic to enable the button.

I have also replaced most usages of `var` and renamed the `code` field (and changed its default value) to make its value more clear, because it stores the message ID, such as `attach-crash-report` and not a numeric value.

Would be good if you could do a quick local test to ensure that everything still works; I did not notice any problems during testing.