### PR TITLE
Duplicate fixed: Remove reference to fix version field

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -376,7 +376,7 @@ messages:
         *Thank you for your report!*
         We're tracking this issue in *%s%*, so this ticket is being resolved and linked as a *duplicate*.
 
-        That ticket has already been resolved as Fixed. Please check the Fix Version/s field in that ticket to see in which version this behavior was or will be fixed.
+        That ticket has already been resolved as Fixed, which means this issue will be fixed in a future update.
 
         If you haven't already, you might like to make use of the [*+search feature+*|https://bugs.mojang.com/issues/?jql=project=%project_id%] to see if the issue has already been mentioned.
 


### PR DESCRIPTION
For Java Edition, with the new version scheme the "Fix version/s" field no longer shows a specific version; as such it no longer makes much sense to refer to that field.

For other projects, I'm not sure to what extent this message was used - and whether it made sense to refer to the future version there. Either way, the phrasing I changed it to should work for all projects.