### PR TITLE
Update telemetry link

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -805,7 +805,7 @@ messages:
 
         Simply stating that "My game is laggy" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
 
-        Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues. To learn more about this, head [here|https://www.minecraft.net/en-us/article/minecraft-snapshot-22w46a] (section "Telemetry") for more information.
+        Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues. To learn more about this, head [here|https://www.minecraft.net/en-us/article/minecraft-java-edition-1-19-3] (section "Telemetry") for more information.
 
         %quick_links%
       fillname: []

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -805,7 +805,7 @@ messages:
 
         Simply stating that "My game is laggy" is not helpful for Mojang to diagnose your issue. If you can pinpoint a specific cause when lag happens for you, please open a new report for that specific issue. If you think this might be a hardware issue please contact *[Community Support|https://discord.gg/58Sxm23]* as they might be able to help with your issue.
 
-        Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues. To learn more about this, head [here|https://www.minecraft.net/en-us/article/minecraft-snapshot-21w38a] (section "Telemetry") for more information.
+        Keep in mind that Mojang is constantly optimizing the game and simply playing the game provides feedback to Mojang on which parts cause performance issues. To learn more about this, head [here|https://www.minecraft.net/en-us/article/minecraft-snapshot-22w46a] (section "Telemetry") for more information.
 
         %quick_links%
       fillname: []


### PR DESCRIPTION
There's a more comprehensive explanation of telemetry in a newer snapshot article.

Would be nice to link to a help article or something instead, but I don't think one exists that explains telemetry to the same extent.