### PR TITLE
Remove custom version from outdated client message

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1086,8 +1086,7 @@ messages:
         In case of a game crash, please also attach the crash report found in {{[minecraft/crash-reports/crash-<DATE>-client.txt|https://minecrafthopper.net/help/finding-minecraft-data-folder/]}}.
 
         %quick_links%
-      fillname:
-        - Enter the latest MC version
+      fillname: []
   panel-environment-desc:
     - project:
         - bds

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1081,7 +1081,7 @@ messages:
         *Thank you for your report!*
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
-        Your Minecraft version is *outdated*. We currently take issues for version *%s%* and the *latest snapshot*.
+        Your Minecraft version is *outdated*. We only take issues for the *latest release* and the *latest snapshot*.
         Please update to the latest version as it includes the newest fixes. If you still have this problem after updating, then please create a new issue.
         In case of a game crash, please also attach the crash report found in {{[minecraft/crash-reports/crash-<DATE>-client.txt|https://minecrafthopper.net/help/finding-minecraft-data-folder/]}}.
 


### PR DESCRIPTION
Looks at closing #215 

Instead of having to input a version for the latest release, it now just says 'latest release'

Also changed 'latest version' -> 'latest release'. Happy to change this back if people think it will cause confusion. Think it sounds a bit more professional to say release over version though