### PR TITLE
Removed reddit link for feedback website

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -717,7 +717,6 @@ messages:
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
         You have posted a feature request or a suggestion. This site is for *bug reports* only.
-
         For suggestions, please visit [Minecraft Suggestions on Reddit|https://feedback.minecraft.net] or visit the [Minecraft Feedback Discord server|https://aka.ms/MinecraftFeedbackDiscord].
 
         %quick_links%

--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -717,7 +717,7 @@ messages:
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
         You have posted a feature request or a suggestion. This site is for *bug reports* only.
-        For suggestions, please visit [Minecraft Suggestions on Reddit|https://www.reddit.com/r/minecraftsuggestions] or visit the [Minecraft Feedback Discord server|https://discord.gg/MXxTqXnuD5].
+        For suggestions, please visit [Minecraft Suggestions on Reddit|https://feedback.minecraft.net] or visit the [Minecraft Feedback Discord server|https://discord.gg/MXxTqXnuD5].
 
         %quick_links%
       fillname: []
@@ -1496,7 +1496,7 @@ messages:
         Please note, that mechanics of the game may change between updates.
         Things such as graphics, sounds, world creation, biomes, redstone, villagers, and animals may not work the same in current versions.
 
-        [Full Version History|https://minecraft.wiki/w/Java_Edition_version_history] -- [Snapshot Version History|https://minecraft.wiki/w/Java_Edition_version_history/Development_versions] -- [Feature Requests and Suggestions|https://www.reddit.com/r/minecraftsuggestions]
+        [Full Version History|https://minecraft.wiki/w/Java_Edition_version_history] -- [Snapshot Version History|https://minecraft.wiki/w/Java_Edition_version_history/Development_versions] -- [Feature Requests and Suggestions|https://feedback.minecraft.net]
 
         %quick_links%
       fillname:
@@ -1514,7 +1514,7 @@ messages:
         Please note, that mechanics of the game may change between updates.
         Things such as graphics, sounds, world creation, biomes, redstone, villagers, and animals may not work the same in current versions.
 
-        [Full Version History|https://minecraft.wiki/w/Bedrock_Edition_version_history] -- [Snapshot Version History|https://minecraft.wiki/w/Bedrock_Edition_version_history/Development_versions] -- [Feature Requests and Suggestions|https://www.reddit.com/r/minecraftsuggestions]
+        [Full Version History|https://minecraft.wiki/w/Bedrock_Edition_version_history] -- [Snapshot Version History|https://minecraft.wiki/w/Bedrock_Edition_version_history/Development_versions] -- [Feature Requests and Suggestions|https://feedback.minecraft.net]
 
         %quick_links%
       fillname:
@@ -1532,7 +1532,7 @@ messages:
         Please note, that mechanics of the game may change between updates.
         Things such as graphics, sounds, world creation, biomes, redstone, villagers, and animals may not work the same in current versions.
 
-        [Full Version History|https://minecraft.wiki/w/Launcher_version_history] -- [Feature Requests and Suggestions|https://www.reddit.com/r/minecraftsuggestions]
+        [Full Version History|https://minecraft.wiki/w/Launcher_version_history] -- [Feature Requests and Suggestions|https://feedback.minecraft.net]
 
         %quick_links%
       fillname:


### PR DESCRIPTION
I believe the website is looked at more frequently than the subreddit (if that''s even official) and this is a parity change also. No other links for feedback go to the subreddit, they all go to the website or discord server.

Could link the discord server instead as I know both are looked at by developers, but not sure which is better.