### PR TITLE
Fix label of feedback site link to say feedback site

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -719,7 +719,7 @@ messages:
         However, this issue is {color:#FF5722}*Invalid*{color}.
 
         You have posted a feature request or a suggestion. This site is for *bug reports* only.
-        For suggestions, please visit [Minecraft Suggestions on Reddit|https://feedback.minecraft.net] or visit the [Minecraft Feedback Discord server|https://aka.ms/MinecraftFeedbackDiscord].
+        For suggestions, please visit [The Minecraft Feedback Site|https://feedback.minecraft.net] or visit the [Minecraft Feedback Discord server|https://aka.ms/MinecraftFeedbackDiscord].
 
         %quick_links%
       fillname: []


### PR DESCRIPTION
One of the feedback site messages still had the Minecraft reddit in the link text.