### PR TITLE
Update GitHub actions & use `actions/setup-node`

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,19 +8,18 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}     
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Cache Node Modules
-        uses: actions/cache@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
+          node-version: 18
+          cache: 'npm'
 
       - name: Install
-        run: npm i
+        run: npm clean-install
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
`actions/setup-node` makes sure that the specified Node.js version is used, and the workflow does not rely implicitly on the Node.js version provided by the runner image.

Also uses `npm clean-install` instead of `npm install` to make sure the `package-lock.json` content matches what is specified in `package.json`, instead of updating it.