### PR TITLE
feat: add mark private comment panel

### DIFF
--- a/assets/messages.yml
+++ b/assets/messages.yml
@@ -1146,6 +1146,24 @@ messages:
         "{panel:borderColor=orange}(!) Your bug report has been marked as _private_,
         as it contains some sensitive privacy information (e.g. an email address or session ID).{panel}"
       fillname: []
+  panel-mark-private-comment:
+    - project:
+        - bds
+        - mc
+        - mcd
+        - mcl
+        - mclg
+        - mcpe
+        - mctest
+        - realms
+        - web
+      name: Panel - Sensitive Information in the Comment
+      shortcut: mkprivcomm
+      category: notice
+      message:
+        "{panel:borderColor=orange}(!) Your comment(s) has been marked as _private_,
+        as it contains some sensitive privacy information (e.g. an email address or session ID).{panel}"
+      fillname: []
   panel-mojang-priority:
     - project:
         - bds


### PR DESCRIPTION
## Changes

Adds panel that indicated the comment was marked as private because it contained sensitive data.

![image](https://github.com/user-attachments/assets/86113277-6942-4513-af83-74026331efed)
