### PR TITLE
Use Node.js 22 for GitHub workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
 
       - name: Install


### PR DESCRIPTION
Node.js 18 is reaching end of maintenance soon: https://nodejs.org/en/about/previous-releases